### PR TITLE
Support streaming transcoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ matrix:
     - os: linux
       env: NODE_VERSION=0.10
     - os: linux
-      env: NODE_VERSION=0.11
+      env: NODE_VERSION=0.12
 script:
   - tools/test-travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 matrix:
   include:
-    - os: osx
-      env: NODE_VERSION=0.8
-    - os: osx
-      env: NODE_VERSION=0.10
-    - os: osx
-      env: NODE_VERSION=0.11
-    - os: linux
-      env: NODE_VERSION=0.8
     - os: linux
       env: NODE_VERSION=0.10
     - os: linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting issues
 
-Here are some guidelines on how to effectively report issues.
+Please start by [reading the FAQ][faq] first.  If your question is not answered, here are some guidelines on how to effectively report issues.
 
 ### Required information
 
@@ -45,3 +45,5 @@ ffmpeg('video with spaces.avi')...;
 // Fails, looks for a file with actual double quotes in its name
 ffmpeg('"video with spaces.avi"')...;
 ```
+
+[faq]: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/wiki/FAQ

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -149,7 +149,7 @@ module.exports = function(proto) {
           var data = parseFfprobeOutput(stdout);
 
           // Handle legacy output with "TAG:x" and "DISPOSITION:x" keys
-          [data.format].concat(data.streams).forEach(function(target) {
+          [data].concat(data.streams).forEach(function(target) {
             var legacyTagKeys = Object.keys(target).filter(legacyTag);
 
             if (legacyTagKeys.length) {

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -105,6 +105,8 @@ module.exports = function(proto) {
       return callback(new Error('Cannot run ffprobe on stream input'));
     }
 
+    var args = ['-show_streams', '-show_format'].concat(this._currentOutput.options.get(), input.source);
+
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
       if (err) {
@@ -119,11 +121,7 @@ module.exports = function(proto) {
       var stderrClosed = false;
 
       // Spawn ffprobe
-      var ffprobe = spawn(path, [
-        '-show_streams',
-        '-show_format',
-        input.source
-      ]);
+      var ffprobe = spawn(path, args);
 
       ffprobe.on('error', function(err) {
         callback(err);
@@ -212,4 +210,3 @@ module.exports = function(proto) {
     });
   };
 };
-

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -78,16 +78,33 @@ module.exports = function(proto) {
    * @method FfmpegCommand#ffprobe
    * @category Metadata
    *
-   * @param {Number} [index] 0-based index of input to probe (defaults to last input)
+   * @param {?Number} [index] 0-based index of input to probe (defaults to last input)
+   * @param {?String[]} [options] array of output options to return
    * @param {FfmpegCommand~ffprobeCallback} callback callback function
    *
    */
-  proto.ffprobe = function(index, callback) {
-    var input;
+  proto.ffprobe = function() {
+    var input, index = null, options = [], callback;
 
-    if (typeof callback === 'undefined') {
-      callback = index;
+    // the last argument should be the callback
+    callback = arguments[arguments.length - 1];
 
+    // map the arguments to the correct variable names
+    switch (arguments.length) {
+      case 3:
+        index = arguments[0];
+        options = arguments[1];
+        break;
+      case 2:
+        if (typeof arguments[0] === 'number') {
+          index = arguments[0];
+        } else if (Array.isArray(arguments[0])) {
+          options = arguments[0];
+        }
+        break;
+    }
+
+    if (index === null) {
       if (!this._currentInput) {
         return callback(new Error('No input specified'));
       }
@@ -105,8 +122,6 @@ module.exports = function(proto) {
       return callback(new Error('Cannot run ffprobe on stream input'));
     }
 
-    var args = ['-show_streams', '-show_format'].concat(this._currentOutput.options.get(), input.source);
-
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
       if (err) {
@@ -121,7 +136,7 @@ module.exports = function(proto) {
       var stderrClosed = false;
 
       // Spawn ffprobe
-      var ffprobe = spawn(path, args);
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, input.source));
 
       ffprobe.on('error', function(err) {
         callback(err);

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -13,16 +13,16 @@ function parseFfprobeOutput(out) {
     streams: []
   };
 
-  function parseBlock() {
+  function parseBlock(name) {
     var data = {};
 
     var line = lines.shift();
     while (line) {
-      if (line.match(/^\[\//)) {
+      if (line.toLowerCase() == '[/'+name+']') {
         return data;
       } else if (line.match(/^\[/)) {
-        lines.unshift(line);
-        return data;
+        line = lines.shift();
+        continue;
       }
 
       var kv = line.match(/^([^=]+)=(.*)$/);
@@ -43,10 +43,10 @@ function parseFfprobeOutput(out) {
   var line = lines.shift();
   while (line) {
     if (line.match(/^\[stream/i)) {
-      var stream = parseBlock();
+      var stream = parseBlock('stream');
       data.streams.push(stream);
     } else if (line.toLowerCase() === '[format]') {
-      data.format = parseBlock();
+      data.format = parseBlock('format');
     }
 
     line = lines.shift();
@@ -162,7 +162,7 @@ module.exports = function(proto) {
           var data = parseFfprobeOutput(stdout);
 
           // Handle legacy output with "TAG:x" and "DISPOSITION:x" keys
-          [data].concat(data.streams).forEach(function(target) {
+          [data.format].concat(data.streams).forEach(function(target) {
             var legacyTagKeys = Object.keys(target).filter(legacyTag);
 
             if (legacyTagKeys.length) {

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -118,10 +118,6 @@ module.exports = function(proto) {
       }
     }
 
-    if (input.isStream) {
-      return callback(new Error('Cannot run ffprobe on stream input'));
-    }
-
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
       if (err) {
@@ -136,7 +132,13 @@ module.exports = function(proto) {
       var stderrClosed = false;
 
       // Spawn ffprobe
-      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, input.source));
+      var src = input.isStream ? 'pipe:0' : input.source
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src));
+
+      if (input.isStream) {
+        input.source.pipe(ffprobe.stdin);
+        input.source.resume();
+      }
 
       ffprobe.on('error', function(err) {
         callback(err);

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -87,7 +87,14 @@ module.exports = function(proto) {
     var input, index = null, options = [], callback;
 
     // the last argument should be the callback
-    callback = arguments[arguments.length - 1];
+    var origCallback = arguments[arguments.length - 1];
+    callback = function() {
+      if (origCallback) {
+        var cb = origCallback;
+        origCallback = null;
+        cb.apply(this, arguments);
+      }
+    };
 
     // map the arguments to the correct variable names
     switch (arguments.length) {
@@ -138,11 +145,11 @@ module.exports = function(proto) {
       if (input.isStream) {
         input.source.pipe(ffprobe.stdin);
         input.source.resume();
+
+        input.source.on('error', callback);
       }
 
-      ffprobe.on('error', function(err) {
-        callback(err);
-      });
+      ffprobe.on('error', callback);
 
       // Ensure we wait for captured streams to end before calling callback
       var exitError = null;

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -209,8 +209,9 @@ FfmpegCommand.getAvailableFormats = function(callback) {
 
 require('./ffprobe')(FfmpegCommand.prototype);
 
-FfmpegCommand.ffprobe = function(file, callback) {
-  (new FfmpegCommand(file)).ffprobe(callback);
+FfmpegCommand.ffprobe = function(file) {
+  var instance = new FfmpegCommand(file);
+  instance.ffprobe.apply(instance, Array.prototype.slice.call(arguments, 1));
 };
 
 /* Add processing recipes */

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -81,6 +81,7 @@ module.exports = function(proto) {
    *
    * The 'options' argument may contain the following keys:
    * - 'niceness': specify process niceness, ignored on Windows (default: 0)
+   * - `cwd`: change working directory
    * - 'captureStdout': capture stdout and pass it to 'endCB' as its 2nd argument (default: false)
    * - 'captureStderr': capture stderr and pass it to 'endCB' as its 3rd argument (default: false)
    *
@@ -428,7 +429,10 @@ module.exports = function(proto) {
       self._spawnFfmpeg(
         args,
 
-        { niceness: self.options.niceness },
+        {
+          niceness: self.options.niceness,
+          cwd: self.options.cwd
+        },
 
         function processCB(ffmpegProc) {
           self.ffmpegProc = ffmpegProc;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -406,8 +406,6 @@ module.exports = function(proto) {
         return emitEnd(err);
       }
 
-      self._ffprobeData = args.ffprobeData;
-
       // Run ffmpeg
       var stdout = null;
       var stderr = '';
@@ -488,8 +486,8 @@ module.exports = function(proto) {
 
             if (self.listeners('progress').length) {
               var duration = 0;
-
-              if (self._ffprobeData && self._ffprobeData.format && self._ffprobeData.format.duration) {
+              var ffprobeData = self.options.ffprobeData || self._ffprobeData;
+              if (ffprobeData && ffprobeData.format && ffprobeData.format.duration) {
                 duration = Number(self._ffprobeData.format.duration);
               }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -353,25 +353,6 @@ module.exports = function(proto) {
         });
       }
     ], callback);
-
-    if (!readMetadata) {
-      // Read metadata as soon as 'progress' listeners are added
-      if (args.ffprobeData) {
-        self._ffprobeData = args.ffprobeData;
-      } else {
-        if (this.listeners('progress').length > 0) {
-          // Read metadata in parallel
-          runFfprobe(this);
-        } else {
-          // Read metadata as soon as the first 'progress' listener is added
-          this.once('newListener', function(event) {
-            if (event === 'progress') {
-              runFfprobe(this);
-            }
-          });
-        }
-      }
-    }
   };
 
 
@@ -424,6 +405,8 @@ module.exports = function(proto) {
       if (err) {
         return emitEnd(err);
       }
+
+      self._ffprobeData = args.ffprobeData;
 
       // Run ffmpeg
       var stdout = null;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -356,17 +356,20 @@ module.exports = function(proto) {
 
     if (!readMetadata) {
       // Read metadata as soon as 'progress' listeners are added
-
-      if (this.listeners('progress').length > 0) {
-        // Read metadata in parallel
-        runFfprobe(this);
+      if (args.ffprobeData) {
+        self._ffprobeData = args.ffprobeData;
       } else {
-        // Read metadata as soon as the first 'progress' listener is added
-        this.once('newListener', function(event) {
-          if (event === 'progress') {
-            runFfprobe(this);
-          }
-        });
+        if (this.listeners('progress').length > 0) {
+          // Read metadata in parallel
+          runFfprobe(this);
+        } else {
+          // Read metadata as soon as the first 'progress' listener is added
+          this.once('newListener', function(event) {
+            if (event === 'progress') {
+              runFfprobe(this);
+            }
+          });
+        }
       }
     }
   };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -492,7 +492,7 @@ module.exports = function(proto) {
               var duration = 0;
               var ffprobeData = self.options.ffprobeData || self._ffprobeData;
               if (ffprobeData && ffprobeData.format && ffprobeData.format.duration) {
-                duration = Number(self._ffprobeData.format.duration);
+                duration = Number(ffprobeData.format.duration);
               }
 
               utils.extractProgress(self, stderr, duration);

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -190,6 +190,9 @@ module.exports = function recipes(proto) {
               }
 
               var duration = Number(vstream.duration);
+              if (isNaN(duration)) {
+                duration = Number(meta.format.duration);
+              }
 
               if (isNaN(duration)) {
                 return next(new Error('Could not get input duration, please specify fixed timemarks'));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -295,7 +295,17 @@ var utils = module.exports = {
       codecObject.video_details = video;
     }
 
-    var codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    var streamInputs = command._inputs.filter(function(input) {
+      return input.isStream;
+    });
+
+    var codecInfoPassed = false;
+    if (streamInputs.length === 0) {
+      codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    } else {
+      codecInfoPassed = /[\r\n]+Output #/.test(stderr);
+    }
+
     if (codecInfoPassed) {
       command.emit('codecData', codecObject);
       command._codecDataSent = true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -330,7 +330,7 @@ var utils = module.exports = {
       var ret = {
         frames: parseInt(progress.frame, 10),
         currentFps: parseInt(progress.fps, 10),
-        currentKbps: parseFloat(progress.bitrate.replace('kbits/s', '')),
+        currentKbps: progress.bitrate ? parseFloat(progress.bitrate.replace('kbits/s', '')) : 0,
         targetSize: parseInt(progress.size, 10),
         timemark: progress.time
       };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 
 var exec = require('child_process').exec;
 var isWindows = require('os').platform().match(/win(32|64)/);
+var which = require('which');
 
 var nlRegexp = /\r\n|\r|\n/g;
 var streamRegexp = /^\[?(.*?)\]?$/;
@@ -216,19 +217,13 @@ var utils = module.exports = {
       return callback(null, whichCache[name]);
     }
 
-    var cmd = 'which ' + name;
-    if (isWindows) {
-      cmd = 'where ' + name + '.exe';
-    }
-
-    exec(cmd, function(err, stdout) {
+    which(name, function(err, result){
       if (err) {
         // Treat errors as not found
-        callback(null, whichCache[name] = '');
-      } else {
-        callback(null, whichCache[name] = stdout.trim());
+        return callback(null, whichCache[name] = '');
       }
-    });
+      callback(null, whichCache[name] = result);
+    })
   },
 
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jsdoc": "latest"
   },
   "dependencies": {
-    "async": ">=0.2.9"
+    "async": ">=0.2.9",
+    "which": "^1.1.1"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "email": "spruce@space-ships.de"
     }
   ],
+  "license": "MIT",
   "bugs": {
     "mail": "schaermu@gmail.com",
     "url": "http://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues"

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -77,6 +77,19 @@ describe('Metadata', function() {
     });
   });
 
+  it('should provide ffprobe extradata_hash in stream information', function(done) {
+    Ffmpeg.ffprobe(this.testfile, ['-show_data_hash', 'sha256'], function(err, data) {
+      testhelper.logError(err);
+      assert.ok(!err);
+
+      ('streams' in data).should.equal(true);
+      Array.isArray(data.streams).should.equal(true);
+      data.streams.length.should.equal(1);
+      data.streams[0].extradata_hash.should.equal('SHA256:837443060e4e47c395b2a817161207395cf0e96545f7d4757c316ea6162cd71d');
+      done();
+    });
+  });
+
   it('should return ffprobe errors', function(done) {
     Ffmpeg.ffprobe('/path/to/missing/file', function(err) {
       assert.ok(!!err);

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -5,6 +5,7 @@
 var Ffmpeg = require('../index'),
   path = require('path'),
   fs = require('fs'),
+  Readable = require('stream').Readable,
   assert = require('assert'),
   exec = require('child_process').exec,
   testhelper = require('./helpers');
@@ -130,6 +131,22 @@ describe('Metadata', function() {
         assert.ok(!err);
         data.streams.length.should.equal(1);
         data.format.filename.should.equal('pipe:0');
+        done();
+      });
+  });
+
+  it('should handle errors on stream input to ffprobe', function(done) {
+    var faultyStream = new Readable({objectMode: true});
+    faultyStream._read = function() {};
+    setTimeout(function() {
+      faultyStream.emit('error', new Error('Dummy stream read error'));
+    }, 50);
+
+    new Ffmpeg()
+      .addInput(faultyStream)
+      .ffprobe(function(err, data) {
+        assert.ok(!!err);
+        err.message.should.equal('Dummy stream read error');
         done();
       });
   });

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -121,14 +121,15 @@ describe('Metadata', function() {
     });
   });
 
-  it('should fail calling ffprobe on a command with stream input', function(done) {
+  it('should allow calling ffprobe on stream input', function(done) {
     var stream = fs.createReadStream(this.testfile);
 
     new Ffmpeg()
       .addInput(stream)
-      .ffprobe(function(err) {
-        assert.ok(!!err);
-        err.message.should.match(/Cannot run ffprobe on stream input/);
+      .ffprobe(function(err, data) {
+        assert.ok(!err);
+        data.streams.length.should.equal(1);
+        data.format.filename.should.equal('pipe:0');
         done();
       });
   });

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -77,15 +77,15 @@ describe('Metadata', function() {
     });
   });
 
-  it('should provide ffprobe extradata_hash in stream information', function(done) {
-    Ffmpeg.ffprobe(this.testfile, ['-show_data_hash', 'sha256'], function(err, data) {
+  it('should provide ffprobe stream information with units', function(done) {
+    Ffmpeg.ffprobe(this.testfile, ['-unit'], function(err, data) {
       testhelper.logError(err);
       assert.ok(!err);
 
       ('streams' in data).should.equal(true);
       Array.isArray(data.streams).should.equal(true);
       data.streams.length.should.equal(1);
-      data.streams[0].extradata_hash.should.equal('SHA256:837443060e4e47c395b2a817161207395cf0e96545f7d4757c316ea6162cd71d');
+      data.streams[0].bit_rate.should.equal('322427 bit/s');
       done();
     });
   });

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -353,6 +353,31 @@ describe('Processor', function() {
         .saveToFile(testFile);
     });
 
+    it('should report codec data through \'codecData\' event for input streams', function(done) {
+      this.timeout(60000);
+      var testFile = path.join(__dirname, 'assets', 'testConvertFromStreamToFileCodecData.flv');
+      this.files.push(testFile);
+
+      var receivedCodecData = false;
+      var instream = fs.createReadStream(this.testfile);
+      this.getCommand({ source: instream, logger: testhelper.logger })
+        .usingPreset('flashvideo')
+        .on('error', function(err, stdout, stderr) {
+          testhelper.logError(err, stdout, stderr);
+          assert.ok(!err);
+        })
+        .on('codecData', function(data) {
+          receivedCodecData = true;
+          data.should.have.property('audio');
+          data.should.have.property('video');
+        })
+        .on('end', function() {
+          assert(receivedCodecData);
+          done();
+        })
+        .saveToFile(testFile);
+    });
+
     it('should report progress through \'progress\' event', function(done) {
       this.timeout(60000);
 

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -55,13 +55,15 @@ describe('Processor', function() {
   // check prerequisites once before all tests
   before(function prerequisites(done) {
     // check for ffmpeg installation
-    this.testfile = path.join(__dirname, 'assets', 'testvideo-43.avi');
-    this.testfilewide = path.join(__dirname, 'assets', 'testvideo-169.avi');
-    this.testfilebig = path.join(__dirname, 'assets', 'testvideo-5m.mpg');
-    this.testfilespecial = path.join(__dirname, 'assets', 'te[s]t_ video \' _ .flv');
-    this.testfileaudio1 = path.join(__dirname, 'assets', 'testaudio-one.wav');
-    this.testfileaudio2 = path.join(__dirname, 'assets', 'testaudio-two.wav');
-    this.testfileaudio3 = path.join(__dirname, 'assets', 'testaudio-three.wav');
+    this.testdir = path.join(__dirname, 'assets');
+    this.testfileName = 'testvideo-43.avi';
+    this.testfile = path.join(this.testdir, this.testfileName);
+    this.testfilewide = path.join(this.testdir, 'testvideo-169.avi');
+    this.testfilebig = path.join(this.testdir, 'testvideo-5m.mpg');
+    this.testfilespecial = path.join(this.testdir, 'te[s]t_ video \' _ .flv');
+    this.testfileaudio1 = path.join(this.testdir, 'testaudio-one.wav');
+    this.testfileaudio2 = path.join(this.testdir, 'testaudio-two.wav');
+    this.testfileaudio3 = path.join(this.testdir, 'testaudio-three.wav');
 
     var self = this;
 
@@ -231,6 +233,22 @@ describe('Processor', function() {
             done();
           })
           .saveToFile(testFile);
+    });
+
+    it('should change the working directory', function(done) {
+      var testFile = path.join(this.testdir, 'testvideo.flv');
+      this.files.push(testFile);
+
+      this.getCommand({ source: this.testfileName, logger: testhelper.logger, cwd: this.testdir })
+        .usingPreset('flashvideo')
+        .on('error', function(err, stdout, stderr) {
+          testhelper.logError(err, stdout, stderr);
+          assert.ok(!err);
+        })
+        .on('end', function() {
+          done();
+        })
+        .saveToFile(testFile);
     });
 
     it('should kill the process on timeout', function(done) {

--- a/tools/test-travis.sh
+++ b/tools/test-travis.sh
@@ -8,12 +8,15 @@ set -e
 echo travis_fold:start:Dependencies
 if [ "$(uname)" = "Linux" ]; then
 	# Linux
-	sudo add-apt-repository -y ppa:jon-severinsson/ffmpeg
 	sudo apt-get update
-	sudo apt-get -y install wget tar bzip2 flvtool2 ffmpeg
-	wget http://ffmpeg.gusari.org/static/64bit/ffmpeg.static.64bit.latest.tar.gz
-	tar zxf ffmpeg.static.64bit.latest.tar.gz
-	sudo cp ffmpeg ffprobe /usr/bin
+	sudo apt-get -y install wget tar bzip2 flvtool2
+
+	wget http://johnvansickle.com/ffmpeg/builds/ffmpeg-git-64bit-static.tar.xz
+	tar xf ffmpeg-git-64bit-static.tar.xz
+
+	sudo cp ffmpeg-git-*-static/{ffmpeg,ffprobe,ffserver} /usr/bin
+	sudo cp ffmpeg-git-*-static/{ffmpeg,ffprobe} $(pwd)
+
 	export ALT_FFMPEG_PATH=$(pwd)/ffmpeg
 	export ALT_FFPROBE_PATH=$(pwd)/ffprobe
 else


### PR DESCRIPTION
The lawlmart branch is a merge of:
- current fluent code
- timdp's fork that supports streaming input ffprobe
- lawlmart's fork that supports streamable streaming transcoding by allowing ffprobe output to sent directly to ffmpeg processor

Merging all of this into this branch would obviously be aggressive. I have a feeling some of the commits from jdp in this branch might duplicate fixes that were merged into the fluent code already? Maybe it makes more sense to start with this and merge in jdp commits?
